### PR TITLE
Public interface traits

### DIFF
--- a/macros/src/owner.rs
+++ b/macros/src/owner.rs
@@ -19,33 +19,21 @@ pub fn expand(meta: OwnerMeta) -> Result<TokenStream, syn::Error> {
     let storage_key =
         storage_key.unwrap_or_else(|| syn::parse_str::<Expr>(DEFAULT_STORAGE_KEY).unwrap());
 
-    let root = quote! {
-        near_contract_tools::slot::Slot::root(#storage_key)
-    };
-
     Ok(TokenStream::from(quote! {
-        impl near_contract_tools::owner::OwnerStorage for #ident {
-            fn is_initialized(&self) -> near_contract_tools::slot::Slot<bool> {
-                #root.field(b"i")
-            }
-
-            fn owner(&self) -> near_contract_tools::slot::Slot<near_sdk::AccountId> {
-                #root.field(b"o")
-            }
-
-            fn proposed_owner(&self) -> near_contract_tools::slot::Slot<near_sdk::AccountId> {
-                #root.field(b"p")
+        impl near_contract_tools::owner::Owner for #ident {
+            fn root(&self) -> near_contract_tools::slot::Slot<()> {
+                near_contract_tools::slot::Slot::root(#storage_key)
             }
         }
 
         #[near_sdk::near_bindgen]
-        impl near_contract_tools::owner::Owner for #ident {
+        impl near_contract_tools::owner::OwnerExternal for #ident {
             fn own_get_owner(&self) -> Option<near_sdk::AccountId> {
-                near_contract_tools::owner::OwnerStorage::owner(self).read()
+                near_contract_tools::owner::Owner::slot_owner(self).read()
             }
 
             fn own_get_proposed_owner(&self) -> Option<near_sdk::AccountId> {
-                near_contract_tools::owner::OwnerStorage::proposed_owner(self).read()
+                near_contract_tools::owner::Owner::slot_proposed_owner(self).read()
             }
 
             #[payable]

--- a/macros/src/pause.rs
+++ b/macros/src/pause.rs
@@ -20,14 +20,14 @@ pub fn expand(meta: PauseMeta) -> Result<TokenStream, syn::Error> {
         storage_key.unwrap_or_else(|| syn::parse_str::<Expr>(DEFAULT_STORAGE_KEY).unwrap());
 
     Ok(TokenStream::from(quote! {
-        impl near_contract_tools::pause::PauseStorage for #ident {
-            fn slot_paused(&self) -> near_contract_tools::slot::Slot<bool> {
+        impl near_contract_tools::pause::Pause for #ident {
+            fn root(&self) -> near_contract_tools::slot::Slot<()> {
                 near_contract_tools::slot::Slot::new(#storage_key)
             }
         }
 
         #[near_sdk::near_bindgen]
-        impl near_contract_tools::pause::Pause for #ident {
+        impl near_contract_tools::pause::PauseExternal for #ident {
             fn paus_is_paused(&self) -> bool {
                 self.is_paused()
             }

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -103,7 +103,7 @@ pub trait Owner {
     fn init(&self, owner_id: AccountId) {
         require!(
             !self.slot_is_initialized().exists(),
-            "Owner already initialized"
+            "Owner already initialized",
         );
 
         self.slot_is_initialized().write(&true);
@@ -145,7 +145,7 @@ pub trait Owner {
                     .read()
                     .as_ref()
                     .unwrap_or_else(|| env::panic_str("No owner")),
-            "Owner only"
+            "Owner only",
         );
     }
 
@@ -186,7 +186,7 @@ pub trait Owner {
 
         require!(
             env::predecessor_account_id() == proposed_owner,
-            "Proposed owner only"
+            "Proposed owner only",
         );
 
         OwnerEvent::Propose {

--- a/src/pause.rs
+++ b/src/pause.rs
@@ -16,12 +16,6 @@ pub enum PauseEvent {
     Unpause,
 }
 
-/// Storage slots for pausable contract
-pub trait PauseStorage {
-    /// Storage slot for pause state
-    fn slot_paused(&self) -> Slot<bool>;
-}
-
 /// Internal-only interactions for a pausable contract
 ///
 /// # Examples
@@ -55,7 +49,15 @@ pub trait PauseStorage {
 ///     }
 /// }
 /// ```
-pub trait Pause: PauseStorage {
+pub trait Pause {
+    /// Storage root
+    fn root(&self) -> Slot<()>;
+
+    /// Storage slot for pause state
+    fn slot_paused(&self) -> Slot<bool> {
+        unsafe { self.root().transmute() }
+    }
+
     /// Force the contract pause state in a particular direction.
     /// Does not emit events or check the current pause state.
     fn set_is_paused(&mut self, is_paused: bool) {
@@ -92,9 +94,10 @@ pub trait Pause: PauseStorage {
     fn require_unpaused(&self) {
         require!(!self.is_paused(), "Disallowed while contract is paused");
     }
+}
 
-    // External methods
-
+/// External methods for `Pause`
+pub trait PauseExternal {
     /// Returns `true` if the contract is paused, `false` otherwise
     fn paus_is_paused(&self) -> bool;
 }

--- a/tests/macros/owner.rs
+++ b/tests/macros/owner.rs
@@ -1,4 +1,7 @@
-use near_contract_tools::{owner::Owner, Owner};
+use near_contract_tools::{
+    owner::{Owner, OwnerExternal},
+    Owner,
+};
 use near_sdk::{
     borsh::{self, BorshSerialize},
     env, near_bindgen,

--- a/tests/macros/pause.rs
+++ b/tests/macros/pause.rs
@@ -1,4 +1,7 @@
-use near_contract_tools::{pause::Pause, Pause};
+use near_contract_tools::{
+    pause::{Pause, PauseExternal},
+    Pause,
+};
 use near_sdk::{
     borsh::{self, BorshSerialize},
     near_bindgen, BorshStorageKey,
@@ -56,7 +59,7 @@ fn derive_pause() {
     assert_eq!(
         contract.paus_is_paused(),
         true,
-        "Pausing the contract works"
+        "Pausing the contract works",
     );
 
     contract.require_paused();
@@ -66,7 +69,7 @@ fn derive_pause() {
     assert_eq!(
         contract.paus_is_paused(),
         false,
-        "Unpausing the contract works"
+        "Unpausing the contract works",
     );
 
     contract.require_unpaused();


### PR DESCRIPTION
`PauseExternal` and `OwnerExternal`.

Separation of concerns / makes `#[near_bindgen]` usage more intuitive & internally consistent.